### PR TITLE
Fixed scoping issue with parameters variable in signal_received

### DIFF
--- a/aws-flow/lib/aws/decider/workflow_definition.rb
+++ b/aws-flow/lib/aws/decider/workflow_definition.rb
@@ -82,6 +82,7 @@ module AWS
         converter = method_pair.data_converter
         method_name = method_pair.method_name
         error_handler do |t|
+          parameters = nil
           t.begin do
             if input.class <= NoInput
               @instance.send(method_name)


### PR DESCRIPTION
Sending a signal with input to a running workflow was causing the workflow to fail. I traced the issue down to a variable that wasn't scoped correctly in the signal_received method of the WorkflowDefinition class. I've included a small patch to resolve the issue. 
