### PR TITLE
Fixed configs for instantiating service object's NetHttpHandler

### DIFF
--- a/aws-flow/lib/aws/decider/task_poller.rb
+++ b/aws-flow/lib/aws/decider/task_poller.rb
@@ -133,7 +133,7 @@ module AWS
       end
 
       def process_single_task(task)
-        @service = AWS::SimpleWorkflow.new.client.with_http_handler(AWS::Core::Http::NetHttpHandler.new(:ssl_ca_file => AWS.config.ssl_ca_file))
+        @service = AWS::SimpleWorkflow.new.client.with_http_handler(AWS::Core::Http::NetHttpHandler.new(AWS.config.to_h))
         begin
           begin
             execute(task)


### PR DESCRIPTION
We had a bug where certain actions like respond_activity_task_completed were not using the proxy that we specified in AWS.config.proxy_uri and were instead trying to send requests directly to the SWF endpoint.

We fixed this by passing all of AWS.config to the NetHttpHandler object when instantiating the service.

Credit to @dansitu for finding the bug and fixing it!
