### PR TITLE
Explicitly require uuidtools

### DIFF
--- a/aws-flow/aws-flow.gemspec
+++ b/aws-flow/aws-flow.gemspec
@@ -12,4 +12,5 @@ Gem::Specification.new do |s|
   s.require_paths << "lib/aws/"
   s.add_dependency "aws-sdk", "~> 1", ">= 1.36.2"
   s.add_dependency "aws-flow-core", ">= 1.0.1"
+  s.add_dependency "uuidtools"
 end

--- a/aws-flow/lib/aws/decider/workflow_client.rb
+++ b/aws-flow/lib/aws/decider/workflow_client.rb
@@ -13,6 +13,8 @@
 # permissions and limitations under the License.
 #++
 
+require 'uuidtools'
+
 module AWS
   module Flow
 


### PR DESCRIPTION
The uuidtools gem is used to generate UUIDs for workflow ids. The gem
was implicitly required via aws-sdk, but aws-sdk has dropped its
uuidtools dependency as of version 1.39.0 (by way of
aws/aws-sdk-ruby#461).

This gem may also wish to eliminate its dependency on uuidtools, but as
with aws-sdk, that would require either implementing a similar backport
of `SecureRandom.uuid` or bumping its aws-sdk requirement to at least
1.39.0 (or deliberately dropping support for older versions of ruby).
