### PR TITLE
Fix issue #37 by covering an edge case

### DIFF
--- a/aws-flow/lib/aws/decider/async_decider.rb
+++ b/aws-flow/lib/aws/decider/async_decider.rb
@@ -404,6 +404,7 @@ module AWS
         @decision_helper[timer_id].consume(:handle_completion_event)
         if @decision_helper[timer_id].done?
           open_request = @decision_helper.scheduled_timers.delete(timer_id)
+          return if open_request.nil?
           open_request.blocking_promise.set(nil)
           open_request.completion_handle.complete
         end


### PR DESCRIPTION
It's possible timer fired to interplay poorly with cancelling the timer, and this should fix that problem. It may be worth reviewing all completion locations to ensure that a similar problem is not present there.

Test case generated based on arkadiyt's report in #37

All tests pass locally. 
