### PR TITLE
fix the default retry function issue

### DIFF
--- a/aws-flow/lib/aws/decider/flow_defaults.rb
+++ b/aws-flow/lib/aws/decider/flow_defaults.rb
@@ -93,7 +93,7 @@ module AWS
         retry_expiration_interval_seconds = options.retry_expiration_interval_seconds
         result = initial_retry_interval * (backoff_coefficient ** (attempts.values.reduce(0, :+) - 2))
         result = maximum_retry_interval_seconds if (! maximum_retry_interval_seconds.nil? && maximum_retry_interval_seconds != INFINITY && result > maximum_retry_interval_seconds)
-        seconds_since_first_attempt = time_of_failure.zero? ? 0 : -(first - time_of_failure).to_i
+        seconds_since_first_attempt = time_of_failure.zero? ? 0 : time_of_failure.to_i
         result = -1 if (! retry_expiration_interval_seconds.nil? &&
                         retry_expiration_interval_seconds != INFINITY &&
                         (result + seconds_since_first_attempt) >= retry_expiration_interval_seconds)

--- a/aws-flow/spec/aws/unit/decider_spec.rb
+++ b/aws-flow/spec/aws/unit/decider_spec.rb
@@ -1501,15 +1501,16 @@ describe FlowConstants do
     :initial_retry_interval => 1,
     :backoff_coefficient => 2,
     :should_jitter => false,
-    :maximum_retry_interval_seconds => 100
+    :maximum_retry_interval_seconds => 100,
+    :retry_expiration_interval_seconds => 300
   }
   options = ExponentialRetryOptions.new(options)
 
   it "will test the default retry function with regular cases" do
-    test_first = [Time.now, Time.now, Time.now]
-    test_time_of_failure = [0, 10, 100]
-    test_attempts = [{Exception=>2}, {Exception=>4}, {ActivityTaskTimedOutException=>5, Exception=>2}]
-    test_output = [1, 4, 32]
+    test_first = [Time.now, Time.now, Time.now, Time.now, Time.now]
+    test_time_of_failure = [0, 10, 100, 199, 200]
+    test_attempts = [{Exception=>2}, {Exception=>4}, {ActivityTaskTimedOutException=>5, Exception=>2}, {Exception=>9}, {Exception=>9}]
+    test_output = [1, 4, 32, 100, -1]
     arr = test_first.zip(test_time_of_failure, test_attempts, test_output)
     arr.each do |first, time_of_failure, attempts, output|
       result = FlowConstants.exponential_retry_function.call(first, time_of_failure, attempts, options)


### PR DESCRIPTION
I think that the default retry function's option 'maximum_retry_interval_seconds' does not work correctly,
because the following code in the default retry function returns a big negative value.

``` ruby
-(first - time_of_failure).to_i
```

For example, on ruby-2.0.0 (MRI) in my environment, above code returns like this.

``` ruby
irb> -(Time.now - 3.0).to_i
=> -1405013309
```

Therefore, the following default retry function's code never return -1 if the 'maximum_retry_interval_seconds' option has been specified.

``` ruby
         seconds_since_first_attempt = time_of_failure.zero? ? 0 : -(first - time_of_failure).to_i
         result = -1 if (! retry_expiration_interval_seconds.nil? &&
                          retry_expiration_interval_seconds != INFINITY &&
                          (result + seconds_since_first_attempt) >= retry_expiration_interval_seconds)
```

So, I fixed this issue with this pull request.

I thought that the second argument for the default retry function is a time-diff(Float) between the current time and the first attempt time.(see: https://github.com/aws/aws-flow-ruby/blob/master/aws-flow/lib/aws/decider/async_retrying_executor.rb#L80)
