### PR TITLE
Log the name and version of the workflow type when no such definition is found in the task handler

### DIFF
--- a/aws-flow/lib/aws/decider/task_handler.rb
+++ b/aws-flow/lib/aws/decider/task_handler.rb
@@ -73,7 +73,7 @@ module AWS
         workflow_type = task.workflow_type
         # TODO put in context correctly
         workflow_definition_factory = @workflow_definition_map[workflow_type]
-        raise "No such definition for #{workflow_type}" if workflow_definition_factory.nil?
+        raise "No workflow definition for #{workflow_type.name}.#{workflow_type.version}" if workflow_definition_factory.nil?
         AsyncDecider.new(workflow_definition_factory, history_helper, DecisionHelper.new)
       end
 


### PR DESCRIPTION
Log the name and version of the workflow type when no such definition is found in the task handler
