### PR TITLE
Allow worker.json to define logging prefs

### DIFF
--- a/aws-flow/lib/aws/decider/utilities.rb
+++ b/aws-flow/lib/aws/decider/utilities.rb
@@ -30,13 +30,20 @@ module AWS
         def self.make_logger(klass)
           make_logger_with_level(klass, Logger::INFO)
         end
+        
         def self.make_logger_with_level(klass, level)
           logname = "#{Dir.tmpdir}/#{klass.class.to_s}"
           logname.gsub!(/::/, '-')
-          log = Logger.new(logname)
-          log.level = level
+          create_logger_from_configuration_hash({:path => logname, :level => level})
+        end
+
+        def self.create_logger_from_configuration_hash(options)
+          raise "Logger option should be a hash" unless options.is_a? Hash
+          log = Logger.new(options[:path])
+          log.level = options[:level]
           log
         end
+
       end
 
       def self.workflow_task_to_debug_string(message, task, task_list)

--- a/aws-flow/lib/aws/decider/version.rb
+++ b/aws-flow/lib/aws/decider/version.rb
@@ -16,7 +16,8 @@
 module AWS
   module Flow
     def self.version
-      "3.1.0"
+      "3.1.1"
     end
   end
 end
+


### PR DESCRIPTION
This will allow worker.json to define the logging preferences.

```
{
   "activity_workers":[
      {
         "logger":{
            "path":"/tmp/foo.log",
            "level":0
         }
      }
   ]
}
```
