### PR TITLE
Make sure and let long polling finish before shutting down

### DIFF
--- a/aws-flow/lib/aws/decider/worker.rb
+++ b/aws-flow/lib/aws/decider/worker.rb
@@ -51,7 +51,6 @@ module AWS
               Kernel.exit! 1
             else
               @shutting_down = true
-              @shutdown_first_time_function.call if @shutdown_first_time_function
             end
           end
         end
@@ -304,10 +303,6 @@ module AWS
           :logger => @logger
         )
 
-        @shutdown_first_time_function = lambda do
-          @executor.shutdown Float::INFINITY
-          Kernel.exit
-        end
         super(service, domain, task_list, *args)
       end
 
@@ -438,7 +433,11 @@ module AWS
           @options
         ) if poller.nil?
 
-        Kernel.exit if @shutting_down
+        if @shutting_down
+          @executor.shutdown Float::INFINITY
+          Kernel.exit
+        end
+
         poller.poll_and_process_single_task(@options.use_forking)
       end
     end


### PR DESCRIPTION
Fixes #31.  

This makes sure that we don't kill the worker process during a long poll.  This will allow the long poll to complete, finish any task returned by the long poll and then kill the process.  We could in theory terminate faster if we could cancel the long poll, but it appears that the AWS SDK doesn't allow that.   

See my comments #31 for a better explanation of the bug and it's root cause.
