### PR TITLE
Raise MissingCredentials error in task poller

### DIFF
--- a/aws-flow/lib/aws/decider/task_poller.rb
+++ b/aws-flow/lib/aws/decider/task_poller.rb
@@ -96,6 +96,9 @@ module AWS
           @logger.info Utilities.workflow_task_to_debug_string("Finished executing task", task, @task_list)
         rescue AWS::SimpleWorkflow::Errors::UnknownResourceFault => e
           @logger.error "Error in the poller, #{e.inspect}"
+        rescue AWS::Errors::MissingCredentialsError => e
+          @logger.error "Error in the poller, #{e.inspect}"
+          raise e
         rescue Exception => e
           @logger.error "Error in the poller, #{e.inspect}"
         end


### PR DESCRIPTION
There was a MissingCredentials error in the poller while aws sdk was getting temporary creds from IAM. But that was not caught. I think the right way would be to upgrade to use aws sdk v2 but this would raise the error so that we can handle it and retry.