### PR TITLE
Use full namespace for Future

### DIFF
--- a/aws-flow/Gemfile
+++ b/aws-flow/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 group :test do
   gem "rspec", "2.14"
-  gem "rake"
+  gem "rake", '< 11.0' # RSpec 2.X is incompatible with newer Rake versions
   gem "factory_girl"
 end

--- a/aws-flow/lib/aws/decider/async_retrying_executor.rb
+++ b/aws-flow/lib/aws/decider/async_retrying_executor.rb
@@ -69,8 +69,8 @@ module AWS
       # @api private
       def invoke(command, attempts, first_attempt_time)
         failure_to_retry = nil
-        should_retry = Future.new
-        return_value = Future.new
+        should_retry = AWS::Flow::Core::Future.new
+        return_value = AWS::Flow::Core::Future.new
         output = Utilities::AddressableFuture.new
         error_handler do |t|
           t.begin { return_value.set(command.call) }

--- a/aws-flow/lib/aws/decider/utilities.rb
+++ b/aws-flow/lib/aws/decider/utilities.rb
@@ -225,7 +225,7 @@ module AWS
         attr_accessor :return_value, :_metadata
         def initialize(initial_metadata = nil)
           @_metadata = initial_metadata
-          @return_value = Future.new
+          @return_value = AWS::Flow::Core::Future.new
         end
 
         # Determines whether the object is a flow future. The contract is that

--- a/aws-flow/lib/aws/decider/workflow_client.rb
+++ b/aws-flow/lib/aws/decider/workflow_client.rb
@@ -91,7 +91,7 @@ module AWS
       #
       def initialize(workflow_execution)
         @_workflow_execution = workflow_execution.dup
-        @return_value = Future.new
+        @return_value = AWS::Flow::Core::Future.new
       end
 
       # Determines whether the object is a flow future. The contract is that flow futures must have a `get` method.
@@ -272,7 +272,7 @@ module AWS
         client_options = Utilities::client_options_from_method_name(method_name, @options)
         options = Utilities::merge_all_options(client_options, options)
 
-        workflow_id_future, run_id_future = Future.new, Future.new
+        workflow_id_future, run_id_future = AWS::Flow::Core::Future.new, AWS::Flow::Core::Future.new
         minimal_domain = MinimalDomain.new(@domain.name.to_s)
         output = WorkflowFuture.new(AWS::Flow::MinimalWorkflowExecution.new(minimal_domain, workflow_id_future, run_id_future))
         new_options = StartWorkflowOptions.new(options)

--- a/aws-flow/lib/aws/decider/workflow_clock.rb
+++ b/aws-flow/lib/aws/decider/workflow_clock.rb
@@ -73,7 +73,7 @@ module AWS
         attributes[:timer_id] = timer_id
         attributes[:start_to_fire_timeout] = delay_seconds.to_s
         open_request = OpenRequestInfo.new
-        open_request.blocking_promise = Future.new
+        open_request.blocking_promise = AWS::Flow::Core::Future.new
         if block
           open_request.result = task do
             open_request.blocking_promise.get

--- a/aws-flow/lib/aws/decider/workflow_definition.rb
+++ b/aws-flow/lib/aws/decider/workflow_definition.rb
@@ -36,8 +36,8 @@ module AWS
 
       def execute(input = nil)
         #TODO Set up all the converter stuff
-        result = Future.new
-        method_output = Future.new
+        result = AWS::Flow::Core::Future.new
+        method_output = AWS::Flow::Core::Future.new
         error_handler do |t|
           t.begin do
             if input.nil?


### PR DESCRIPTION
This fixes #126, in which Future is resolved to
java.util.concurrent.Future in JRuby.